### PR TITLE
Fix missing yarn build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ else
     echo "failed, will create a new database from template"
 fi
 yarn migrate
+yarn build
 
 # Run post-install tasks
 sudo ./install_post.sh


### PR DESCRIPTION
As per title, fix missing `yarn build` in `install.sh`.